### PR TITLE
README.md: Add link to standalone alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 This code is free to use but if you want to show support you may <br><a href="https://www.buymeacoffee.com/llamafilm" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 40px !important;width: 144px !important;" ></a>
 
+Allows [Tesla Custom Integration](https://github.com/alandtse/tesla) to use the new Fleet API.
+Read the [Docs](tesla_http_proxy/DOCS.md) to see how to set this up.
+
+## Home Assistant Core
+
+Users of Home Assistant Core might be interested in this alternative: https://github.com/functionpointer/tesla-http-proxy-standalone
+
 ## Add-ons
 
 This repository contains the following add-ons


### PR DESCRIPTION
This Add-On is fantastic. However, it doesn't work for Home Assistant Core users.

I have created a standalone-version by borrowing the relevant code from this repo.
Given the popularity of this Add-On, it would be great if there was a link to it in the README.

I know this repo also has a standalone mode. However, it seems to still host its own nginx and seems more for CI than for actual usage.